### PR TITLE
fix: :bug: fixed Liekd's verification

### DIFF
--- a/model/v1/like.go
+++ b/model/v1/like.go
@@ -9,7 +9,7 @@ import (
 type Like struct {
 	ObjMeta  `json:",inline"`
 	UserName string `json:"username" gorm:"primaryKey;column:username"`
-	ItemType string `json:"item_type" gorm:"primaryKey;column:item_type" validate:"required;oneof:post,comment"`
+	ItemType string `json:"item_type" gorm:"primaryKey;column:item_type" validate:"required,oneof=post comment"`
 	ItemID   uint   `json:"item_id" gorm:"primaryKey;column:item_id" validate:"required"`
 }
 


### PR DESCRIPTION
This pull request updates the validation syntax for the `ItemType` field in the `Like` struct within the `model/v1/like.go` file. The change ensures compatibility with the latest validation library.

Validation update:

* [`model/v1/like.go`](diffhunk://#diff-e31f08f025b39c577336b49f1120cf2fe2672c73b0818d2330bbeb98805fb75bL12-R12): Modified the `validate` tag for the `ItemType` field to use `oneof=post comment` instead of `oneof:post,comment`, aligning with the updated syntax requirements of the validation library.