### PR TITLE
Release version v0.1.2-hotfix.1

### DIFF
--- a/internal/apiserver/app.go
+++ b/internal/apiserver/app.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	version = "0.1.1"
+	version = "0.1.2"
 )
 
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
This pull request includes a minor update to the `Like` struct in the `model/v1/like.go` file. The change modifies the validation syntax for the `ItemType` field.

Validation update:

* [`model/v1/like.go`](diffhunk://#diff-e31f08f025b39c577336b49f1120cf2fe2672c73b0818d2330bbeb98805fb75bL12-R12): Updated the `validate` tag for the `ItemType` field to use `required,oneof=post comment` instead of `required;oneof:post,comment`, aligning with the correct validation syntax.