### PR TITLE
Hotfix

### DIFF
--- a/model/v1/like.go
+++ b/model/v1/like.go
@@ -9,7 +9,7 @@ import (
 type Like struct {
 	ObjMeta  `json:",inline"`
 	UserName string `json:"username" gorm:"primaryKey;column:username"`
-	ItemType string `json:"item_type" gorm:"primaryKey;column:item_type" validate:"required;oneof:post,comment"`
+	ItemType string `json:"item_type" gorm:"primaryKey;column:item_type" validate:"required,oneof=post comment"`
 	ItemID   uint   `json:"item_id" gorm:"primaryKey;column:item_id" validate:"required"`
 }
 


### PR DESCRIPTION
This pull request includes a minor update to the validation syntax in the `Like` model to align with the correct format for specifying validation rules.

Validation update:

* [`model/v1/like.go`](diffhunk://#diff-e31f08f025b39c577336b49f1120cf2fe2672c73b0818d2330bbeb98805fb75bL12-R12): Updated the `validate` tag for the `ItemType` field to use `required,oneof=post comment` instead of `required;oneof:post,comment` for proper validation syntax.