### PR TITLE
Fix subscription check key from item_id to item_name

### DIFF
--- a/internal/apiserver/controller/v1/subscribe/check.go
+++ b/internal/apiserver/controller/v1/subscribe/check.go
@@ -22,7 +22,7 @@ func (c *SubscribeController) Check(ctx *gin.Context) {
 	mapper := map[string]string{
 		"item_type": ctx.Param("type"),
 		"username":  opUserName,
-		"item_id":   ctx.Param("resourceid"),
+		"item_name": ctx.Param("resourceid"),
 	}
 
 	selector := v1.Selector(mapper)


### PR DESCRIPTION
Correct the key used in the subscription check to ensure proper identification of the item.