### PR TITLE
Release version v0.1.2-hotfix.2

### DIFF
--- a/internal/apiserver/controller/v1/subscribe/check.go
+++ b/internal/apiserver/controller/v1/subscribe/check.go
@@ -22,7 +22,7 @@ func (c *SubscribeController) Check(ctx *gin.Context) {
 	mapper := map[string]string{
 		"item_type": ctx.Param("type"),
 		"username":  opUserName,
-		"item_id":   ctx.Param("resourceid"),
+		"item_name": ctx.Param("resourceid"),
 	}
 
 	selector := v1.Selector(mapper)

--- a/model/v1/like.go
+++ b/model/v1/like.go
@@ -9,7 +9,7 @@ import (
 type Like struct {
 	ObjMeta  `json:",inline"`
 	UserName string `json:"username" gorm:"primaryKey;column:username"`
-	ItemType string `json:"item_type" gorm:"primaryKey;column:item_type" validate:"required;oneof:post,comment"`
+	ItemType string `json:"item_type" gorm:"primaryKey;column:item_type" validate:"required,oneof=post comment"`
 	ItemID   uint   `json:"item_id" gorm:"primaryKey;column:item_id" validate:"required"`
 }
 


### PR DESCRIPTION
This pull request includes a small but important change to the `SubscribeController`'s `Check` method. The change updates the key in the `mapper` from `"item_id"` to `"item_name"` to better reflect the data being passed.

* [`internal/apiserver/controller/v1/subscribe/check.go`](diffhunk://#diff-da87e85367591f014b40f7a3824c9d7e28313ec48ccfd37602ab9740cd98027fL25-R25): Updated the key in the `mapper` from `"item_id"` to `"item_name"` in the `Check` method to align with the expected parameter usage.