### PR TITLE
fix: :bug: fix validation tag format error in Subscribe structure

### DIFF
--- a/model/v1/subscribe.go
+++ b/model/v1/subscribe.go
@@ -11,7 +11,7 @@ import (
 type Subscribe struct {
 	ObjMeta  `json:",inline"`
 	UserName string `json:"username" gorm:"column:username;uniqueIndex:idx_username_itemtype_itemid;type:varchar(255)" validate:"required"`
-	ItemType string `json:"item_type" gorm:"column:item_type;uniqueIndex:idx_username_itemtype_itemid;type:varchar(255)" validate:"required;oneof=user"`
+	ItemType string `json:"item_type" gorm:"column:item_type;uniqueIndex:idx_username_itemtype_itemid;type:varchar(255)" validate:"required,oneof=user"`
 	ItemName string `json:"item_name" gorm:"column:item_name;uniqueIndex:idx_username_itemtype_itemid;type:varchar(255)" validate:"required"`
 }
 


### PR DESCRIPTION
This pull request includes a small change to the `Subscribe` struct in the `model/v1/subscribe.go` file. The change updates the `validate` tag for the `ItemType` field to use a comma (`,`) instead of a semicolon (`;`) to separate validation rules, aligning it with the correct syntax.Fix validation tag format error in Subscribe structure.