### PR TITLE
Remove unnecessary type parameter from subscribe route

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -2,7 +2,7 @@ name: Dependency Update
 
 on:
   schedule:
-    - cron: '0 3 * * 1'  # 每周一凌晨 3 点运行
+    - cron: '0 3 * * 1'
 
 jobs:
   update-dependencies:
@@ -17,6 +17,16 @@ jobs:
         with:
           go-version: 1.20
 
+      - name: Set Go Module Path
+        run: |
+          go env -w GO111MODULE=on
+          go env -w GOPROXY=https://proxy.golang.org,direct
+          go env -w GOMODCACHE=$HOME/go/pkg/mod
+          go env -w GOPATH=$HOME/go
+          mkdir -p $GOPATH/src/github.com/ividernvi
+          ln -s $GITHUB_WORKSPACE $GOPATH/src/github.com/ividernvi/algohub
+          cd $GOPATH/src/github.com/ividernvi/algohub
+
       - name: Update dependencies
         run: go get -u ./...
 
@@ -28,4 +38,4 @@ jobs:
           git commit -m "chore: update dependencies"
           git push
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/internal/apiserver/controller/v1/subscribe/list.go
+++ b/internal/apiserver/controller/v1/subscribe/list.go
@@ -22,8 +22,7 @@ func (c *SubscribeController) List(ctx *gin.Context) {
 	}
 
 	mapper := map[string]string{
-		"item_type": ctx.Param("type"),
-		"username":  ctx.Param("id"),
+		"username": ctx.Param("id"),
 	}
 
 	selector := v1.Selector(mapper)

--- a/internal/apiserver/route.go
+++ b/internal/apiserver/route.go
@@ -50,7 +50,7 @@ func RegisterRoutes(e *gin.Engine) {
 			user.GET("/:id/:type/like", likeController.List)
 
 			// user subscribe items
-			user.GET("/:id/:type/subscribe", subscribeController.List)
+			user.GET("/:id/subscribe", subscribeController.List)
 
 			// user avatar
 			user.PUT("/:id/avatar", authorize, mustLogin, userController.PutAvatar)


### PR DESCRIPTION
This pull request includes updates to simplify API routes, modify controller logic, and extend the `User` model. The most important changes involve removing unused parameters from the `SubscribeController` logic, updating the corresponding API route, and adding a new field to the `User` model.

### API Route Simplification:
* Updated the `subscribe` route in `RegisterRoutes` to remove the `:type` parameter, simplifying the endpoint to `/user/:id/subscribe`.

### Controller Logic Update:
* Removed the unused `item_type` parameter from the `mapper` in the `SubscribeController.List` method.

### Model Extension:
* Added a new `IpAddress` field to the `User` model to store user IP addresses.