### PR TITLE
feat: :sparkles: add comment image upload interface

### DIFF
--- a/internal/apiserver/controller/v1/comment/pugimage.go
+++ b/internal/apiserver/controller/v1/comment/pugimage.go
@@ -1,0 +1,39 @@
+package comment
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/gin-gonic/gin"
+	v1 "github.com/ividernvi/algohub/model/v1"
+	"github.com/ividernvi/algohub/pkg/core"
+	"github.com/ividernvi/algohub/pkg/util/idutil"
+	"github.com/sirupsen/logrus"
+)
+
+func (p *CommentController) PutImage(ctx *gin.Context) {
+	dataBytes, err := io.ReadAll(ctx.Request.Body)
+	if err != nil {
+		core.WriteResponse(ctx, err, nil)
+		return
+	}
+
+	if ctx.ContentType() != "image/png" && ctx.ContentType() != "image/jpeg" && ctx.ContentType() != "image/jpg" && ctx.ContentType() != "image/gif" {
+		logrus.Warnf("invalid file type: %s", ctx.ContentType())
+		core.WriteResponse(ctx, core.ErrInvalidFileType, nil)
+		return
+	}
+
+	imageUrl, err := p.Service.Subjects().Put(ctx, &v1.PutOptions{
+		Realm:      "algohub-comment",
+		File_UUID:  fmt.Sprintf("%s-%s-%s", ctx.Param("id"), ctx.Param("commentid"), idutil.UUID()),
+		File_Bytes: dataBytes,
+		File_type:  ctx.ContentType(),
+	})
+	if err != nil {
+		core.WriteResponse(ctx, err, nil)
+		return
+	}
+
+	core.WriteResponse(ctx, nil, imageUrl)
+}

--- a/internal/apiserver/route.go
+++ b/internal/apiserver/route.go
@@ -71,6 +71,7 @@ func RegisterRoutes(e *gin.Engine) {
 			post.POST("/:id/comment/", authorize, mustLogin, commentController.Create)
 			post.PUT("/:id/comment/:commentid", authorize, mustLogin, commentController.Update)
 			post.DELETE("/:id/comment/:commentid", authorize, mustLogin, commentController.Delete)
+			post.PUT("/:id/comment/:commentid/image", authorize, mustLogin, commentController.PutImage)
 		}
 
 		like := v1.Group("/like")


### PR DESCRIPTION
Add comment image upload interface
This pull request introduces a new feature to handle image uploads for comments in the API server. The primary changes include the addition of a new controller method to process image uploads and the registration of a corresponding route.

### New Feature: Image Upload for Comments

* **Added `PutImage` method in `CommentController`:**  
  A new method `PutImage` was implemented in `internal/apiserver/controller/v1/comment/pugimage.go`. This method handles image uploads, validates the file type (supports PNG, JPEG, JPG, and GIF), and stores the image using the `Subjects` service. The response includes the URL of the uploaded image.

* **Registered a new route for image uploads:**  
  The route `PUT /:id/comment/:commentid/image` was added to the API in `internal/apiserver/route.go`. This route is protected by `authorize` and `mustLogin` middleware and maps to the new `PutImage` method in `CommentController`.