### PR TITLE
fix: :bug: ensure the subscribe record of soft deletion is also deleted.

### DIFF
--- a/internal/apiserver/store/mysql/subscribe.go
+++ b/internal/apiserver/store/mysql/subscribe.go
@@ -56,5 +56,5 @@ func (s *subscribeStore) Update(ctx context.Context, subscribe *v1.Subscribe, op
 }
 
 func (s *subscribeStore) Delete(ctx context.Context, sub *v1.Subscribe, opts *v1.DeleteOptions) error {
-	return s.db.Where("username = ? AND item_type = ? AND item_name = ?", sub.UserName, sub.ItemType, sub.ItemName).Delete(&v1.Subscribe{}).Error
+	return s.db.Unscoped().Where("username = ? AND item_type = ? AND item_name = ?", sub.UserName, sub.ItemType, sub.ItemName).Delete(&v1.Subscribe{}).Error
 }


### PR DESCRIPTION
When deleting a subscription, it was added that Unscoped to ensure that the record of soft deletion is also deleted.