### PR TITLE
Release version v0.1.2-hotfix.8

### DIFF
--- a/internal/apiserver/controller/v1/comment/delete.go
+++ b/internal/apiserver/controller/v1/comment/delete.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (c *CommentController) Delete(ctx *gin.Context) {
-	id, err := strconv.Atoi(ctx.Param("id"))
+	id, err := strconv.Atoi(ctx.Param("commentid"))
 	if err != nil {
 		core.WriteResponse(ctx, err, nil)
 		return


### PR DESCRIPTION
This pull request includes a minor change to the `Delete` method in `internal/apiserver/controller/v1/comment/delete.go`. The change updates the parameter name from `"id"` to `"commentid"` to improve clarity and accuracy.

* [`internal/apiserver/controller/v1/comment/delete.go`](diffhunk://#diff-4fbebd9d7fdf71587554c2fbb75ac3063e11cba6ac816819e8066a03493c9951L11-R11): Updated the parameter in `ctx.Param` from `"id"` to `"commentid"` in the `Delete` method.